### PR TITLE
Add persistent Wifi Credentials?

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ of reveal.js. We'll rebase over time to bring in new features.
 
 ## Updating the presentation
 
-This presentation ends up live at http://mhvlug.org/live
+This presentation ends up live at [http://mhvlug.org/live](http://mhvlug.org/live)
 
 If you would like to help update, please get on github and provide a
 pull request, or ask to join the group.
+
+## Testing locally
+
+To test this on your local machine you will need to `git clone` [reveal.js](https://github.com/hakimel/reveal.js) inside of the project file, at the same level as index.html.  It has already been included in the `.gitignore` file.

--- a/index.html
+++ b/index.html
@@ -34,29 +34,14 @@
 
     <div class="reveal">
       <div class="header">
-        Welcome to <span class="mhvlug">MHVLUG</span>
+          <div class='left'>Welcome to <span class="mhvlug">MHVLUG</span></div>
+          <div class='right'><p id="WiFiHeader"><a class="space"></a><i>Wifi Password:</i> <b> mQgJRQAp</b></p></div>
       </div>
 
       <!-- Any section element inside of this container is displayed as a slide -->
       <div class="slides">
 	<section style="text-align: left">
           <h3 class="prespre">Tonight's Presentation:</h3>
-          <h3 class="prestitle">Linux where you least expect it</h3>
-
-          <img class="talk" src="http://mhvlug.org/sites/default/files/images/17-Ubuntoo-1320436541-large.jpg">
-          <br/>
-          <p>
-            Tonight's Agenda:
-          </p>
-          <p class="agenda">5:00 - Open Room</p>
-          <p class="agenda">6:05 - 10 years of MHVLUG in Data</p>
-          <p class="agenda">6:15 - Lightning Talks</p>
-          <p class="agenda">7:00 - Cake and Celebration</p>
-
-	</section>
-
-	<section style="text-align: left">
-          <h3 class="prespre">Next Month:</h3>
           <h3 class="prestitle">Typography: Physical
             Art to Digital Art</h3>
           <img class="talk" src="http://mhvlug.org/sites/default/files/u26/type_anat.jpg">
@@ -72,6 +57,16 @@
             of type onto digital media, including a discussion
             of fonts, formats and tools for type design.
           </p>
+
+	</section>
+
+	<section style="text-align: left">
+          <h3 class="prespre">Next Month:</h3>
+          <h3 class="prestitle">Asterix</h3>
+                    <br/>
+          <p class="abstract">
+          </p>
+
 
 	</section>
 

--- a/mhvlug/mhvlug.css
+++ b/mhvlug/mhvlug.css
@@ -165,6 +165,7 @@ body {
     top: 0.3em;
     left: 0.3em;
     font-weight: bold;
+    width: 100%;
 }
 
 .reveal h3 {
@@ -203,4 +204,30 @@ body {
 
 .reveal .drupal {
     color: #0173BA;
+}
+
+/***********************************************************
+ * WiFi Header
+ */
+ 
+ .space {
+  width: 20px;
+  height: 18px;
+  display: inline-block;
+}
+
+.left {
+  display:inline-block;
+}
+
+.right{
+  display:inline-block;
+  float: right;
+  position: relative;
+  right: 0.5em;
+  top: 0.4em;
+}
+
+#WiFiHeader {
+    font-size: 18px;
 }


### PR DESCRIPTION
 _The transitions were a bit too quick for folks to catch the wifi credentials so I added a couple different options for displaying them persistently._
### Header
- Looks good floated to the right
- may need some `<i>` and `<b>` work
### Footer
- needed to include jQuery to append it to the progress bar
- also needed to use a negative top margin to get it to display.

**If you choose to keep this, one probably should be deleted.** I prefer the header myself...
#### Other tweaks
- cleaned up some tabs in `index.html`
- deleted first slide in preparation for the next meeting
- added reference and instructions for reveal.js in `README.md` so it can be tested locally before pull requests are made
